### PR TITLE
fix: fix conflict on addresses views

### DIFF
--- a/addresses/serializers.py
+++ b/addresses/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from .models import Address
 from users.serializers import UserSerializer
 
+
 class AddressSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)
 

--- a/addresses/views.py
+++ b/addresses/views.py
@@ -6,6 +6,8 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.permissions import IsAdminUser
 from users.permissions import IsAccountOwner
 from .permissions import IsAddressOwner
+from django.db import IntegrityError
+from rest_framework.views import Response, status
 
 
 class CreateAddressView(generics.CreateAPIView):
@@ -16,10 +18,17 @@ class CreateAddressView(generics.CreateAPIView):
 
     def perform_create(self, serializer):
         serializer.save(user_id=self.kwargs.get(self.lookup_field))
+        # try:
+        #     serializer.save(user_id=self.kwargs.get(self.lookup_field))
+        # except IntegrityError as error:
+        #     error_message = str(error)
+        #     return Response(data={
+        #         "error": error_message},
+        #         status=status.HTTP_409_CONFLICT
+        #     )
 
 
 class AddressDetailView(generics.RetrieveUpdateDestroyAPIView):
-
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAdminUser | IsAddressOwner]
     queryset = Address.objects.all()

--- a/users/urls.py
+++ b/users/urls.py
@@ -8,6 +8,12 @@ urlpatterns = [
     path("users/", users_views.ListUsersView.as_view()),
     path("users/login/", jwt_views.TokenObtainPairView.as_view()),
     path("users/<int:pk>/", users_views.UserDetailView.as_view()),
-    path("users/<int:pk>/addresses/", addresses_views.CreateAddressView.as_view()),
-    path("users/<int:pk>/addresses/", addresses_views.AddressDetailView.as_view()),
+    path(
+        "users/<int:pk>/addresses/create/",
+        addresses_views.CreateAddressView.as_view()
+    ),
+    path(
+        "users/<int:pk>/addresses/",
+        addresses_views.AddressDetailView.as_view()
+    ),
 ]


### PR DESCRIPTION
The addresses views was resulting in conflict because the endpoint of two different views was the same. Aparently this conflict just happens when using query params. Check the changes on addresses urls to update the insomnia.